### PR TITLE
Add toleration for new control-plane taint

### DIFF
--- a/helm/calico-policy-only/templates/calico-crd-installer.yaml
+++ b/helm/calico-policy-only/templates/calico-crd-installer.yaml
@@ -68,6 +68,8 @@ spec:
           operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
       restartPolicy: Never
       serviceAccountName: calico-crd-installer
   backoffLimit: 4


### PR DESCRIPTION
This PR adds a toleration for the node-role.kubernetes.io/control-plane taint to resources that already have a toleration to the deprecated node-role.kubernetes.io/master taint.
Towards giantswarm/roadmap#2471
